### PR TITLE
Adding JS auto-resize features and CSS line-break formatting for display views in forms

### DIFF
--- a/app/templates/add_ticket.html
+++ b/app/templates/add_ticket.html
@@ -9,11 +9,19 @@
     <form method="post">
         <h3>User Info</h3>
         <label>Name:</label>
-        <input type="text" name="user_name" required><br>
+        <input type="text"
+               name="user_name" required
+               placeholder="Enter your name..."
+        ><br>
 
         <h3>Issue</h3>
         <label>Issue Description:</label><br>
-        <textarea name="issue_description" required></textarea><br>
+        <textarea name="issue_description" required
+                  class="auto-resize"
+                  rows="4"
+                  style="width: 100%; resize: vertical; overflow-y: hidden;"
+                  placeholder="Enter issue description..."
+        ></textarea><br>
 
         <h3>Device Type</h3>
         <select name="device_type" required>
@@ -25,11 +33,24 @@
             <option value="Switch">Switch</option>
             <option value="Tablet">Tablet</option>
             <option value="Other">Other</option>
-        </select><br>
-
+        </select><br><br>
         <input type="submit" value="Submit Ticket">
     </form>
 
     <a href="{{ url_for('routes.index') }}">Back to Tickets</a>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const textareas = document.querySelectorAll('.auto-resize');
+        textareas.forEach(textarea => {
+            const resize = () => {
+                textarea.style.height = 'auto';
+                textarea.style.height = textarea.scrollHeight + 'px';
+            };
+            resize();
+            textarea.addEventListener('input', resize);
+        });
+    });
+    </script>
 </body>
 </html>

--- a/app/templates/edit_ticket.html
+++ b/app/templates/edit_ticket.html
@@ -47,10 +47,20 @@
         </select>
 
         <label>Issue:</label>
-        <textarea name="issue_description" > {{ ticket.issue_description }}</textarea>
+        <textarea name="issue_description"
+                  class="auto-resize"
+                  rows="4"
+                  style="width: 100%; resize: vertical; overflow-y: hidden;"
+                  placeholder="Enter issue description..."
+        >{{ ticket.issue_description }}</textarea>
 
         <label>Troubleshooting</label><br>
-        <textarea name="troubleshooting">{{ ticket.troubleshooting or '' }}</textarea><br>
+        <textarea name="troubleshooting"
+                  class="auto-resize"
+                  rows="4"
+                  style="width: 100%; resize: vertical; overflow-y: hidden;"
+                  placeholder="Enter troubleshooting steps..."
+        >{{ ticket.troubleshooting or '' }}</textarea><br>
 
         <label>Priority:</label>
         <select name="priority">
@@ -116,5 +126,19 @@
 
     <br>
     <a href="{{ url_for('troubleshooting.troubleshooting_dashboard') }}">Back to Dashboard</a>
+
+    <script>
+    document.addEventListener('DOMContentLoaded', function () {
+        const textareas = document.querySelectorAll('.auto-resize');
+        textareas.forEach(textarea => {
+            const resize = () => {
+                textarea.style.height = 'auto';
+                textarea.style.height = textarea.scrollHeight + 'px';
+            };
+            resize();
+            textarea.addEventListener('input', resize);
+        });
+    });
+    </script>
 </body>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -28,9 +28,9 @@
             <td>{{ ticket.id }}</td>
             <td>{{ ticket.user_name }}</td>
             <td>{{ ticket.device_code }}</td>
-            <td>{{ ticket.issue_description }}</td>
+            <td><div style="white-space: pre-wrap;">{{ ticket.issue_description or '' }}</div></td>
             <td>{{ ticket.date_reported }}</td>
-            <td>{{ ticket.troubleshooting or '' }}</td>
+            <td><div style="white-space: pre-wrap;">{{ ticket.troubleshooting or '' }}</div></td>
             <td>{{ ticket.status }}</td>
             <td>
                 <form action="{{ url_for('routes.delete_ticket', id=ticket.id) }}" method="post" style="display:inline">

--- a/app/templates/troubleshooting.html
+++ b/app/templates/troubleshooting.html
@@ -64,8 +64,8 @@
                 <td>{{ ticket.priority or '—' }}</td>
                 <td>{{ ticket.category or '—' }}</td>
                 <td>{{ ticket.assigned_to or '—' }}</td>
-                <td>{{ ticket.issue_description }}</td>
-                <td>{{ ticket.troubleshooting or 'N/A' }}</td>
+                <td><div style="white-space: pre-wrap;">{{ ticket.issue_description }}</div></td>
+                <td><div style="white-space: pre-wrap;">{{ ticket.troubleshooting or 'N/A' }}</div></td>
                 <td class="{{ ticket.status|lower|replace(' ', '-') }}">{{ ticket.status }}</td>
                 <td>{{ ticket.due_date.strftime('%Y-%m-%d') if ticket.due_date else '—' }}</td>
                 <td>{{ ticket.date_reported.strftime('%Y-%m-%d') if ticket.date_reported else '—' }}</td>


### PR DESCRIPTION
Closes #6 

Added two key front-end features to improve how long text is handled in both the ticket input forms and display tables across Clarus. First, auto-resizing `<textarea>` fields now expand vertically as the user types. This allows users to see all their input at once (especially helpful for troubleshooting notes) without being confined to a small, fixed-height box. Second, line-break preservation for displayed text ensures that when `issue_description` and `troubleshooting data` are shown in ticket lists, the original formatting (like new lines and spacing) is retained, making multi-step instructions much easier to read.

## Summary
-  Auto-resizing `<textarea>` fields using JavaScript for all relevant input forms (`add_ticket.html` and `edit_tickets.html`).
- Line-break formatting using `white-space: pre-wrap` for display-only fields in `index.html` and `troubleshooting.html`.

## Notes
- Implemented using JavaScript that listens for the input event on any `<textarea class="auto-resize">`.
  - I referred to this article entitled, "[Dynamically expand height of input type "text" based on number of characters typed into field](https://stackoverflow.com/questions/23818131/dynamically-expand-height-of-input-type-text-based-on-number-of-characters-typ)."
  - On each input, it first resets the height to `auto`, then sets it to `scrollHeight`, which matches the actual content height.
  - This keeps the `textarea` height perfectly in sync with the number of lines being typed.
  - Applied in `add_ticket.html` and `edit_tickets.html` for `issue_description` and `troubleshooting`.
- Used inline CSS: `style="white-space: pre-wrap;" inside a <div>` wrapping the displayed text.
  - I referred to [How to insert line breaks in HTML documents using CSS](https://stackoverflow.com/questions/65849/how-to-insert-line-breaks-in-html-documents-using-css)
  - This allows line breaks `(\n)` and spacing to show up exactly as entered by the user, no collapsing into one long line.
  - Applied to both `issue_description` and `troubleshooting` fields in `index.html` and `troubleshooting.html`.


