### PR TITLE
Implemented role-based access and flash message fix in portal

### DIFF
--- a/app/db.py
+++ b/app/db.py
@@ -3,9 +3,9 @@ from flask import current_app
 
 def get_db_connection():
     return mysql.connector.connect(
-        host=current_app.config.get('MYSQL_HOST', 'localhost'),
-        user=current_app.config.get('MYSQL_USER', 'root'),
-        password=current_app.config.get('MYSQL_PASSWORD', 'Xchaosweaver24!'),
+        host=current_app.config.get('MYSQL_HOST'),
+        user=current_app.config.get('MYSQL_USER'),
+        password=current_app.config.get('MYSQL_PASSWORD'),
         database=current_app.config.get('MYSQL_DB', 'itflask')
     )
 

--- a/app/management.py
+++ b/app/management.py
@@ -1,7 +1,7 @@
 # app/management.py
 from flask import Blueprint, render_template, request, redirect, url_for, flash
 from flask_login import login_required
-
+from app.routes import roles_required
 from .db import get_db_connection
 from datetime import datetime
 
@@ -9,6 +9,7 @@ troubleshooting_bp = Blueprint('troubleshooting', __name__, url_prefix='/trouble
 
 @troubleshooting_bp.route('/', methods=['GET'])
 @login_required
+@roles_required('admin', 'support')
 def troubleshooting_dashboard():
     conn = get_db_connection()
     cursor = conn.cursor(dictionary=True)

--- a/app/static/auth.css
+++ b/app/static/auth.css
@@ -369,3 +369,21 @@ form{ width: 100%; }
   background-color: #f8d7da;
   color: #721c24;
 }
+
+.flash.register_error {
+  background-color: #f8d7da;
+  color: #721c24;
+}
+.flash.register_success {
+  background-color: #d4edda;
+  color: #155724;
+}
+.flash.login_error {
+  background-color: #f8d7da;
+  color: #721c24;
+}
+.flash.logout {
+  background-color: #d1ecf1;
+  color: #0c5460;
+}
+

--- a/app/templates/aims.html
+++ b/app/templates/aims.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Asset Inventory Management</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h2>Asset Inventory Management System (AIMS)</h2>
+            <a href="{{ url_for('routes.portal') }}" class="btn btn-outline-secondary">Back to Portal</a>
+        </div>
+
+        <div class="card shadow-sm">
+            <div class="card-body">
+                <h5 class="card-title">Coming Soon</h5>
+                <p class="card-text">This section will allow HR/admins to track and manage company-owned IT assets assigned to employees.</p>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/app/templates/eip.html
+++ b/app/templates/eip.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Employee Identity Portal</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <h2 class="mb-4">Employee Identity Portal (EIP)</h2>
+        <p>This section will let you view and manage employee identity data.</p>
+        <p class="text-muted">Feature coming soon.</p>
+        <a href="{{ url_for('routes.portal') }}" class="btn btn-outline-primary mt-3">Back to Portal</a>
+    </div>
+</body>
+</html>
+

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,7 +12,7 @@
 
     {% if current_user.is_authenticated %}
       <script>
-        window.location.href = "{{ url_for('troubleshooting.troubleshooting_dashboard') }}";
+        window.location.href = "{{ url_for('routes.portal') }}";
       </script>
     {% endif %}
 
@@ -24,7 +24,9 @@
           {% with messages = get_flashed_messages(with_categories=true) %}
             {% if messages %}
               {% for category, message in messages %}
-                <div class="flash {{ category }}">{{ message }}</div>
+                {% if category in ['login_error', 'logout'] %}
+                  <div class="flash {{ category }}">{{ message }}</div>
+                {% endif %}
               {% endfor %}
             {% endif %}
           {% endwith %}
@@ -59,11 +61,13 @@
       </div>
 
       <div class="form-box register">
-        <form method="POST" action="{{ url_for('routes.login_register') }}">
+        <form method="POST" action="{{ url_for('routes.register') }}">
           {% with messages = get_flashed_messages(with_categories=true) %}
             {% if messages %}
               {% for category, message in messages %}
-                <div class="flash {{ category }}">{{ message }}</div>
+                {% if category in ['register_error', 'register_success'] %}
+                  <div class="flash {{ category }}">{{ message }}</div>
+                {% endif %}
               {% endfor %}
             {% endif %}
           {% endwith %}
@@ -115,6 +119,13 @@
         }
       });
     </script>
-
+    <script>
+      const flashMessages = {{ get_flashed_messages(with_categories=true) | tojson }};
+      flashMessages.forEach(([category, message]) => {
+        if (category.startsWith('register_')) {
+          document.querySelector('.container').classList.add('active'); // Show register form
+        }
+      });
+    </script>
   </body>
 </html>

--- a/app/templates/portal.html
+++ b/app/templates/portal.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Clarus Portal</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h2>{{ welcome_message }}</h2>
+            <a href="{{ url_for('routes.logout') }}" class="btn btn-outline-danger">Logout</a>
+        </div>
+        {% with messages = get_flashed_messages(with_categories=true) %}
+            {% if messages %}
+                {% for category, message in messages %}
+                    {% if category == 'login_success' %}
+                        <div class="alert alert-success text-center" role="alert">
+                            {{ message }}
+                        </div>
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
+        {% endwith %}
+
+        <div class="row justify-content-center g-4">
+            {% if 'troubleshooting' in modules %}
+            <div class="col-md-4">
+                <div class="card h-100 shadow-sm">
+                    <div class="card-body text-center">
+                        <h5 class="card-title">IT Support</h5>
+                        <p class="card-text">Manage and resolve IT support tickets.</p>
+                        <a href="{{ url_for('troubleshooting.troubleshooting_dashboard') }}" class="btn btn-primary w-100">Open Dashboard</a>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
+
+            {% if 'inventory' in modules %}
+            <div class="col-md-4">
+                <div class="card h-100 shadow-sm">
+                    <div class="card-body text-center">
+                        <h5 class="card-title">Asset Inventory (AIMS)</h5>
+                        <p class="card-text">Track and manage organizational IT assets.</p>
+                        <a href="{{ url_for('routes.aims') }}" class="btn btn-success w-100">Access Inventory</a>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
+
+            {% if 'eip' in modules %}
+            <div class="col-md-4">
+                <div class="card h-100 shadow-sm">
+                    <div class="card-body text-center">
+                        <h5 class="card-title">Employee Identity Portal (EIP)</h5>
+                        <p class="card-text">View and manage employee identity data.</p>
+                        <a href="{{ url_for('routes.eip') }}" class="btn btn-info w-100">Open EIP</a>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
+
+            {% if 'profile' in modules %}
+            <div class="col-md-4">
+                <div class="card h-100 shadow-sm">
+                    <div class="card-body text-center">
+                        <h5 class="card-title">Profile Management</h5>
+                        <p class="card-text">Edit and view your personal profile information.</p>
+                        <a href="{{ url_for('routes.profile') }}" class="btn btn-warning w-100">Manage Profile</a>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
+        </div>
+    </div>
+
+    <!-- Bootstrap JS Bundle -->
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>

--- a/app/templates/profile.html
+++ b/app/templates/profile.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Profile Management</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+</head>
+<body class="bg-light">
+    <div class="container py-5">
+        <div class="d-flex justify-content-between align-items-center mb-4">
+            <h2>Profile Management</h2>
+            <a href="{{ url_for('routes.portal') }}" class="btn btn-outline-secondary">Back to Portal</a>
+        </div>
+
+        <div class="card shadow-sm">
+            <div class="card-body">
+                <h5 class="card-title mb-3">Account Details</h5>
+                <ul class="list-group list-group-flush">
+                    <li class="list-group-item"><strong>Username:</strong> {{ current_user.username }}</li>
+                    <li class="list-group-item"><strong>Email:</strong> {{ current_user.email }}</li>
+                    <li class="list-group-item"><strong>Role:</strong> {{ current_user.role }}</li>
+                </ul>
+            </div>
+        </div>
+    </div>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Closes #17 

## Summary:
- Implemented role-based access control for EIP, AIMS, and Troubleshooting routes
- Users without the right roles can no longer access restricted pages, even through direct URLs
- Fixed issue where registration flash messages (e.g., "user already exists") weren’t showing
- Problem was due to the dual-form layout defaulting to the login view on page load
- Added JavaScript that detects `"register_"` flash messages and auto-switches to the registration form
- Flash messages now appear on the correct form without needing to manually toggle

## Notes:
- Used `@roles_required(...)` decorators to enforce access based on roles
- Flash messages categorized as `register_success`, `register_error`, `login_error`, etc.
- `auth.css` updated to include specific styles for each flash category
- JavaScript enhancement added to `index.html` to check for registration messages and apply `.active` class to switch form
- Verified behavior for both successful and failed login/registration cases
- Need to create the role management page for `admin` (because for now, it has the same access with `support` so I need to increase `admin` users authority)