### PR TITLE
Clarus restructuring

### DIFF
--- a/app/routes.py
+++ b/app/routes.py
@@ -3,7 +3,6 @@ from flask_login import login_user, logout_user, current_user, login_required
 from functools import wraps
 from .models import get_user_by_username, verify_user, verify_reset_token, generate_reset_token, get_user_by_email, insert_user
 from .db import get_db_connection
-from datetime import datetime
 from werkzeug.security import generate_password_hash
 import smtplib
 import psycopg2
@@ -11,6 +10,99 @@ import psycopg2.extras
 from email.mime.text import MIMEText
 
 bp = Blueprint('routes', __name__)
+
+
+def get_portal_modules(role):
+    modules = [{
+        'key': 'profile',
+        'title': 'My Profile',
+        'description': 'View your employee record, upload documents, and keep your personal information up to date.',
+        'cta': 'Open Profile',
+        'endpoint': 'profile.view_profile',
+        'icon': 'profile'
+    }]
+
+    if role in ['admin', 'hr', 'support']:
+        modules.append({
+            'key': 'change_requests',
+            'title': 'Change Review',
+            'description': 'Review employee profile updates, supporting notes, and approval decisions from one queue.',
+            'cta': 'Review Requests',
+            'endpoint': 'change_requests.change_requests_dashboard',
+            'icon': 'requests'
+        })
+        modules.append({
+            'key': 'inventory',
+            'title': 'Asset Records',
+            'description': 'Track employee-issued devices and internal assets in one inventory workspace.',
+            'cta': 'Open Assets',
+            'endpoint': 'routes.aims',
+            'icon': 'assets'
+        })
+    if role in ['admin', 'support']:
+        modules.append({
+            'key': 'troubleshooting',
+            'title': 'IT Service Desk',
+            'description': 'Handle support tickets and troubleshooting as a secondary operations module inside Clarus.',
+            'cta': 'Open Service Desk',
+            'endpoint': 'troubleshooting.troubleshooting_dashboard',
+            'icon': 'support'
+        })
+    if role in ['admin']:
+        modules.append({
+            'key': 'manage_role',
+            'title': 'Access Management',
+            'description': 'Manage employee access levels and keep role assignments aligned with HR responsibilities.',
+            'cta': 'Manage Access',
+            'endpoint': 'routes.manage_role',
+            'icon': 'shield'
+        })
+
+    return modules
+
+
+def get_portal_stats(user_id, role):
+    conn = get_db_connection()
+    cursor = conn.cursor(cursor_factory=psycopg2.extras.DictCursor)
+
+    try:
+        cursor.execute(
+            "SELECT COUNT(*) AS total FROM change_requests WHERE user_id = %s AND status = 'Pending'",
+            (user_id,)
+        )
+        my_pending_requests = cursor.fetchone()['total']
+
+        cursor.execute(
+            "SELECT COUNT(*) AS total FROM user_documents WHERE user_id = %s",
+            (user_id,)
+        )
+        my_documents = cursor.fetchone()['total']
+
+        stats = [
+            {'label': 'My Pending Requests', 'value': my_pending_requests},
+            {'label': 'My Uploaded Documents', 'value': my_documents},
+        ]
+
+        if role in ['admin', 'hr', 'support']:
+            cursor.execute(
+                "SELECT COUNT(*) AS total FROM change_requests WHERE status = 'Pending'"
+            )
+            pending_reviews = cursor.fetchone()['total']
+
+            cursor.execute(
+                "SELECT COUNT(*) AS total FROM user_documents WHERE status = 'Pending'"
+            )
+            pending_documents = cursor.fetchone()['total']
+
+            stats.extend([
+                {'label': 'Pending Approvals', 'value': pending_reviews},
+                {'label': 'Documents Awaiting Review', 'value': pending_documents},
+            ])
+
+        return stats
+    finally:
+        cursor.close()
+        conn.close()
 
 def get_recent_notifications(user_id, role, limit=10):
     conn = get_db_connection()
@@ -199,29 +291,19 @@ def reset_password(token):
 @bp.route('/portal')
 @login_required
 def portal():
-    modules = []
     role = getattr(current_user, 'role', 'basic')
-
-    if role in ['admin']:
-        modules.append('manage_role')
-    if role in ['admin', 'support']:
-        modules.append('troubleshooting')
-    if role in ['admin', 'hr', 'support']:
-        modules.append('inventory')
-    if role in ['admin', 'hr', 'support']:
-        modules.append('eip')
-
-    modules.append('profile')
-
     welcome_message = f"Welcome back, {current_user.username}!"
-
     notifications = get_recent_notifications(current_user.id, role)
+    modules = get_portal_modules(role)
+    stats = get_portal_stats(current_user.id, role)
 
     return render_template(
         'portal.html',
         modules=modules,
+        stats=stats,
         welcome_message=welcome_message,
-        notifications=notifications
+        notifications=notifications,
+        portal_subtitle="Your employee self-service hub for records, requests, and internal updates."
     )
 
 @bp.route('/notifications-panel')

--- a/app/static/css/change_requests.css
+++ b/app/static/css/change_requests.css
@@ -1,0 +1,124 @@
+[data-bs-theme="light"] table.table-striped.table-hover tbody > tr.row-approved > td {
+  background-color: #d1e7dd !important;
+  color: #0f5132 !important;
+}
+
+[data-bs-theme="dark"] table.table-striped.table-hover tbody > tr.row-approved > td {
+  background-color: #145c46 !important;
+  color: #d1fae5 !important;
+}
+
+[data-bs-theme="light"] table.table-striped.table-hover tbody > tr.row-pending > td {
+  background-color: #fff3cd !important;
+  color: #664d03 !important;
+}
+
+[data-bs-theme="dark"] table.table-striped.table-hover tbody > tr.row-pending > td {
+  background-color: #6e5400 !important;
+  color: #fff7d6 !important;
+}
+
+[data-bs-theme="light"] table.table-striped.table-hover tbody > tr.row-declined > td {
+  background-color: #f8d7da !important;
+  color: #842029 !important;
+}
+
+[data-bs-theme="dark"] table.table-striped.table-hover tbody > tr.row-declined > td {
+  background-color: #842029 !important;
+  color: #ffe1e1 !important;
+}
+
+[data-bs-theme="dark"] table.table-striped.table-hover tbody > tr.row-default > td {
+  background-color: #2c2c2c !important;
+  color: #f1f1f1 !important;
+}
+
+[data-bs-theme="light"] table.table-striped.table-hover tbody > tr.row-odd > td {
+  background-color: rgba(0, 0, 0, 0.03);
+}
+
+[data-bs-theme="dark"] table.table-striped.table-hover tbody > tr.row-odd > td {
+  background-color: rgba(255, 255, 255, 0.05);
+}
+
+[data-bs-theme="light"] tr[data-status]:hover {
+  background-color: rgba(13, 110, 253, 0.1);
+}
+
+[data-bs-theme="dark"] tr[data-status]:hover {
+  background-color: rgba(13, 110, 253, 0.2);
+}
+
+tr[data-status] {
+  transition: background-color 0.3s ease;
+}
+
+.filter-card {
+  background-color: var(--bs-card-bg);
+  padding: 1.5rem;
+  border-radius: 12px;
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.3s ease, transform 0.3s ease;
+}
+
+[data-bs-theme="light"] .filter-card:hover {
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
+  transform: scale(1.01);
+}
+
+[data-bs-theme="dark"] .filter-card {
+  box-shadow: 0 0 16px rgba(255, 255, 255, 0.08);
+}
+
+[data-bs-theme="dark"] .filter-card:hover {
+  box-shadow: 0 4px 24px rgba(255, 255, 255, 0.1), 0 1px 3px rgba(255, 255, 255, 0.05);
+  transform: scale(1.01);
+}
+
+.table-wrapper {
+  background-color: var(--bs-card-bg);
+  padding: 1rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 0 6px rgba(0, 0, 0, 0.05);
+}
+
+.fade-in {
+  animation: fadeIn 0.5s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.pagination .page-link {
+  transition: background-color 0.2s, color 0.2s, transform 0.2s;
+  border: none;
+  margin: 0 2px;
+  border-radius: 6px;
+}
+
+.pagination .page-link:hover {
+  background-color: rgba(13, 110, 253, 0.15);
+  color: var(--bs-primary);
+  transform: translateY(-1px);
+}
+
+.pagination .page-item.active .page-link {
+  background-color: var(--bs-primary);
+  border-color: var(--bs-primary);
+  color: #fff;
+  font-weight: 600;
+}
+
+[data-bs-theme="dark"] .pagination .page-link:hover {
+  background-color: rgba(13, 110, 253, 0.3);
+  color: #fff;
+}

--- a/app/static/css/main.css
+++ b/app/static/css/main.css
@@ -1,0 +1,30 @@
+:root[data-bs-theme="light"] {
+  --bs-body-bg: #f8f9fa;
+  --bs-body-color: #212529;
+}
+
+:root[data-bs-theme="dark"] {
+  --bs-body-bg: #121212;
+  --bs-body-color: #f8f9fa;
+}
+
+body {
+  background-color: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+
+#themeToggle {
+  font-size: 1.25rem;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+[data-bs-theme="dark"] #themeIcon {
+  color: white;
+}
+
+[data-bs-theme="light"] #themeIcon {
+  color: #212529;
+}

--- a/app/static/css/portal.css
+++ b/app/static/css/portal.css
@@ -1,0 +1,160 @@
+.glass-effect {
+  background: rgba(255, 255, 255, 0.1);
+  backdrop-filter: blur(20px);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.dark .glass-effect {
+  background: rgba(0, 0, 0, 0.3);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.thread-gradient {
+  background: linear-gradient(45deg, #303294, #E5DA3C, #EE1A22, #303294);
+  background-size: 400% 400%;
+  animation: gradientShift 2s ease-in-out infinite;
+}
+
+@keyframes gradientShift {
+  0% {
+    background-position: 0% 50%;
+  }
+
+  50% {
+    background-position: 100% 50%;
+  }
+
+  100% {
+    background-position: 0% 50%;
+  }
+}
+
+.perspective-card {
+  perspective: 1000px;
+}
+
+.card-3d {
+  position: relative;
+  overflow: hidden;
+  transform-style: preserve-3d;
+  transition: transform 0.6s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.card-3d:hover {
+  transform: rotateY(10deg) rotateX(5deg) translateZ(20px);
+}
+
+.card-3d::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: -100%;
+  width: 200%;
+  height: 100%;
+  background: linear-gradient(
+    120deg,
+    rgba(255, 255, 255, 0) 0%,
+    rgba(255, 255, 255, 0.3) 50%,
+    rgba(255, 255, 255, 0) 100%,
+    transparent 60%
+  );
+  transform: skewX(-25deg);
+  opacity: 0;
+  transition: opacity 1s ease;
+  pointer-events: none;
+  z-index: 1;
+}
+
+.card-3d:hover::before {
+  animation: metallic-glint 1.5s ease-in-out infinite;
+  opacity: 1;
+}
+
+@keyframes metallic-glint {
+  0% {
+    left: -75%;
+  }
+
+  50% {
+    left: 100%;
+  }
+
+  100% {
+    left: 100%;
+  }
+}
+
+.module-glow {
+  box-shadow: 0 0 30px rgba(48, 50, 148, 0.3);
+  transition: box-shadow 0.3s ease;
+}
+
+.module-glow:hover {
+  box-shadow: 0 0 50px rgba(48, 50, 148, 0.5);
+}
+
+.shimmer-bg {
+  display: inline-block;
+  position: relative;
+  color: transparent;
+  background: linear-gradient(
+    90deg,
+    #ffffff 0%,
+    #dddddd 40%,
+    #ffffff 60%,
+    #cccccc 100%
+  );
+  background-size: 200% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: shimmer 2s linear infinite;
+}
+
+.shimmer-hover {
+  position: relative;
+  color: black;
+  font-weight: bold;
+  transition: all 0.3s ease;
+}
+
+.shimmer-hover::after {
+  content: attr(data-text);
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  color: transparent;
+  background: linear-gradient(45deg, transparent, white 40%, transparent);
+  background-size: 200% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: shimmer 2s linear infinite;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+}
+
+.shimmer-hover:hover::after {
+  opacity: 1;
+}
+
+.animate-shimmer {
+  animation: shimmer 2s linear infinite;
+}
+
+.blink {
+  animation: blink 1s step-start 0s infinite;
+}
+
+@keyframes blink {
+  50% {
+    opacity: 0;
+  }
+}
+
+body.modal-open {
+  padding-right: 0 !important;
+}

--- a/app/static/css/profile.css
+++ b/app/static/css/profile.css
@@ -1,0 +1,118 @@
+.nav-tabs .nav-link {
+  position: relative;
+  transition: background-color 0.3s, color 0.3s, transform 0.2s;
+}
+
+.nav-tabs .nav-link:hover {
+  background-color: rgba(13, 110, 253, 0.15);
+  transform: translateY(-2px);
+  color: var(--bs-primary);
+  border-color: transparent;
+  cursor: pointer;
+}
+
+[data-bs-theme="dark"] .nav-tabs .nav-link:hover {
+  background-color: rgba(13, 110, 253, 0.3);
+}
+
+.nav-tabs .nav-link.active {
+  font-weight: bold;
+  border-bottom: 2px solid var(--bs-primary);
+}
+
+.profile-card {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  padding: 1.5rem;
+  border-radius: 12px;
+  background-color: var(--bs-card-bg);
+  box-shadow: 0 0 12px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.3s, transform 0.3s ease;
+}
+
+.profile-left {
+  flex: 0 0 auto;
+}
+
+.profile-right {
+  flex: 1 1 auto;
+  animation: fadeIn 0.5s ease;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+[data-bs-theme="dark"] .profile-card {
+  box-shadow: 0 0 16px rgba(255, 255, 255, 0.08);
+}
+
+.profile-card:hover {
+  box-shadow: 0 4px 24px rgba(0, 0, 0, 0.3), 0 1px 3px rgba(0, 0, 0, 0.2);
+  transform: scale(1.01);
+}
+
+[data-bs-theme="dark"] .profile-card:hover {
+  box-shadow: 0 4px 24px rgba(255, 255, 255, 0.1), 0 1px 3px rgba(255, 255, 255, 0.05);
+  transform: scale(1.01);
+}
+
+.profile-avatar {
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.profile-avatar:hover {
+  transform: scale(1.05);
+  box-shadow: 0 4px 20px rgba(0, 123, 255, 0.25);
+}
+
+.change-modal-overlay {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 1rem;
+  background: rgba(15, 23, 42, 0.58);
+  z-index: 2000;
+}
+
+.change-modal-overlay.is-open {
+  display: flex;
+}
+
+.change-modal-panel {
+  width: min(100%, 32rem);
+  border-radius: 16px;
+  background: var(--bs-body-bg);
+  color: var(--bs-body-color);
+  box-shadow: 0 24px 80px rgba(0, 0, 0, 0.28);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.change-modal-header,
+.change-modal-footer {
+  padding: 1rem 1.25rem;
+  border-color: rgba(128, 128, 128, 0.2);
+}
+
+.change-modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.2);
+}
+
+.change-modal-body {
+  padding: 1.25rem;
+}

--- a/app/static/js/change_requests.js
+++ b/app/static/js/change_requests.js
@@ -1,0 +1,17 @@
+(function () {
+  function repaintRows() {
+    document.querySelectorAll("tr").forEach((row) => {
+      row.style.display = "none";
+      void row.offsetHeight;
+      row.style.display = "";
+    });
+  }
+
+  function handleThemeChange() {
+    repaintRows();
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    document.addEventListener("clarus:theme-changed", handleThemeChange);
+  });
+})();

--- a/app/static/js/portal.js
+++ b/app/static/js/portal.js
@@ -1,0 +1,97 @@
+(function () {
+  const phrases = [
+    "Your employee records, clarified.",
+    "Self-service for every update.",
+    "Built for people operations.",
+  ];
+
+  let phraseIndex = 0;
+  let charIndex = 0;
+  let isDeleting = false;
+  let tagline = null;
+
+  function typewriter() {
+    const currentPhrase = phrases[phraseIndex];
+    tagline.textContent = currentPhrase.slice(0, charIndex);
+
+    if (!isDeleting) {
+      if (charIndex < currentPhrase.length) {
+        charIndex += 1;
+        setTimeout(typewriter, 40);
+      } else {
+        isDeleting = true;
+        setTimeout(typewriter, 500);
+      }
+    } else if (charIndex > 0) {
+      charIndex -= 1;
+      setTimeout(typewriter, 40);
+    } else {
+      isDeleting = false;
+      phraseIndex = (phraseIndex + 1) % phrases.length;
+      setTimeout(typewriter, 50);
+    }
+  }
+
+  function toggleNotificationBox() {
+    const notificationBox = document.getElementById("notificationBox");
+    if (notificationBox) {
+      notificationBox.classList.toggle("hidden");
+    }
+  }
+
+  function toggleReminderBox() {
+    const reminderBox = document.getElementById("newReminderBox");
+    if (reminderBox) {
+      reminderBox.classList.toggle("hidden");
+    }
+  }
+
+  function togglePortalTheme() {
+    document.documentElement.classList.toggle("dark");
+  }
+
+  window.addEventListener("load", () => {
+    const loader = document.getElementById("loader");
+    const main = document.getElementById("main-content");
+    tagline = document.getElementById("typewriter");
+
+    if (tagline) {
+      tagline.style.display = "inline";
+      typewriter();
+    }
+
+    setTimeout(() => {
+      loader.style.opacity = "0";
+      loader.style.transform = "scale(0.95)";
+
+      setTimeout(() => {
+        loader.style.display = "none";
+        main.classList.remove("hidden");
+        main.style.animation = "fadeIn 1s ease-in-out";
+      }, 400);
+    }, 2000);
+  });
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const toggleNotificationBtn = document.getElementById("toggleNotificationBtn");
+    if (toggleNotificationBtn) {
+      toggleNotificationBtn.addEventListener("click", toggleNotificationBox);
+    }
+
+    const toggleReminderBtn = document.getElementById("toggleReminderBtn");
+    const closeReminderBtn = document.getElementById("closeReminderBtn");
+    const cancelReminderBtn = document.getElementById("cancelReminderBtn");
+
+    if (toggleReminderBtn) {
+      toggleReminderBtn.addEventListener("click", toggleReminderBox);
+    }
+    if (closeReminderBtn) {
+      closeReminderBtn.addEventListener("click", toggleReminderBox);
+    }
+    if (cancelReminderBtn) {
+      cancelReminderBtn.addEventListener("click", toggleReminderBox);
+    }
+  });
+
+  window.togglePortalTheme = togglePortalTheme;
+})();

--- a/app/static/js/profile.js
+++ b/app/static/js/profile.js
@@ -1,0 +1,197 @@
+(function () {
+  function getProfileRoot() {
+    return document.getElementById("profilePage");
+  }
+
+  function getRequestChangeUrl() {
+    return getProfileRoot()?.dataset.requestChangeUrl || "";
+  }
+
+  function cleanupChangeModalState() {
+    const modalElement = document.getElementById("changeModal");
+    if (!modalElement) {
+      return;
+    }
+
+    modalElement.classList.remove("is-open");
+    modalElement.setAttribute("aria-hidden", "true");
+    document.body.style.removeProperty("overflow");
+  }
+
+  function resetChangeRequestModal() {
+    const changeField = document.getElementById("changeField");
+    const changeNote = document.getElementById("changeNote");
+    const inputGroup = document.getElementById("inputGroup");
+    const submitButton = document.getElementById("changeRequestSubmit");
+
+    if (changeField) {
+      changeField.value = "";
+    }
+    if (changeNote) {
+      changeNote.value = "";
+    }
+    if (inputGroup) {
+      inputGroup.innerHTML = "";
+    }
+    if (submitButton) {
+      submitButton.disabled = false;
+      submitButton.textContent = "Send Request";
+    }
+  }
+
+  function buildChangeRequestInput(triggerButton) {
+    const field = triggerButton?.dataset.changeField || "";
+    const type = triggerButton?.dataset.changeType || "text";
+    const options = (triggerButton?.dataset.changeOptions || "")
+      .split("|")
+      .map((option) => option.trim())
+      .filter(Boolean);
+
+    document.getElementById("changeField").value = field;
+    document.getElementById("changeNote").value = "";
+
+    const group = document.getElementById("inputGroup");
+    group.innerHTML = "";
+
+    const label = document.createElement("label");
+    label.className = "form-label";
+    label.setAttribute("for", "newValue");
+    label.innerText = "Requested Value";
+    group.appendChild(label);
+
+    let input;
+    if (options.length > 0) {
+      input = document.createElement("select");
+      input.className = "form-select";
+
+      const placeholder = document.createElement("option");
+      placeholder.value = "";
+      placeholder.disabled = true;
+      placeholder.selected = true;
+      placeholder.text = "-- Select a value --";
+      input.appendChild(placeholder);
+
+      options.forEach((option) => {
+        const choice = document.createElement("option");
+        choice.value = option;
+        choice.text = option;
+        input.appendChild(choice);
+      });
+    } else if (type === "textarea") {
+      input = document.createElement("textarea");
+      input.className = "form-control";
+      input.rows = 3;
+      input.value = "";
+    } else {
+      input = document.createElement("input");
+      input.className = "form-control";
+      input.type = type;
+      input.value = "";
+    }
+
+    input.id = "newValue";
+    input.required = true;
+    group.appendChild(input);
+  }
+
+  function closeChangeRequestModal() {
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+    cleanupChangeModalState();
+    resetChangeRequestModal();
+  }
+
+  function openChangeRequestModal(triggerButton) {
+    resetChangeRequestModal();
+    buildChangeRequestInput(triggerButton);
+
+    const modalElement = document.getElementById("changeModal");
+    cleanupChangeModalState();
+    modalElement.classList.add("is-open");
+    modalElement.setAttribute("aria-hidden", "false");
+    document.body.style.overflow = "hidden";
+
+    const newValueInput = document.getElementById("newValue");
+    if (newValueInput) {
+      newValueInput.focus();
+    }
+  }
+
+  function submitChangeRequest(event) {
+    event.preventDefault();
+
+    const requestChangeUrl = getRequestChangeUrl();
+    const field = document.getElementById("changeField").value;
+    const newValueInput = document.getElementById("newValue");
+
+    if (!requestChangeUrl || !newValueInput) {
+      alert("Unable to open the change request form correctly. Please try again.");
+      return;
+    }
+
+    const submitButton = document.getElementById("changeRequestSubmit");
+    submitButton.disabled = true;
+    submitButton.textContent = "Sending...";
+
+    fetch(requestChangeUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        field,
+        new_value: newValueInput.value,
+        note: document.getElementById("changeNote").value,
+      }),
+    })
+      .then((response) => {
+        if (response.ok) {
+          alert("Your update request was submitted for review.");
+          closeChangeRequestModal();
+          return;
+        }
+
+        alert("Unable to submit your update request.");
+        submitButton.disabled = false;
+        submitButton.textContent = "Send Request";
+      })
+      .catch(() => {
+        alert("Unable to submit your update request.");
+        submitButton.disabled = false;
+        submitButton.textContent = "Send Request";
+      });
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    const changeModalElement = document.getElementById("changeModal");
+    changeModalElement.addEventListener("click", (event) => {
+      if (event.target === changeModalElement) {
+        closeChangeRequestModal();
+      }
+    });
+
+    document.body.addEventListener("htmx:beforeSwap", () => {
+      if (changeModalElement.classList.contains("is-open")) {
+        closeChangeRequestModal();
+      }
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (event.key === "Escape" && changeModalElement.classList.contains("is-open")) {
+        closeChangeRequestModal();
+      }
+    });
+
+    document.getElementById("profileTab").addEventListener("shown.bs.tab", () => {
+      if (changeModalElement.classList.contains("is-open")) {
+        closeChangeRequestModal();
+      } else {
+        resetChangeRequestModal();
+        cleanupChangeModalState();
+      }
+    });
+  });
+
+  window.openChangeRequestModal = openChangeRequestModal;
+  window.closeChangeRequestModal = closeChangeRequestModal;
+  window.submitChangeRequest = submitChangeRequest;
+})();

--- a/app/templates/portal.html
+++ b/app/templates/portal.html
@@ -2,12 +2,13 @@
 <html lang="en" class="scroll-smooth">
 <head>
   <meta charset="UTF-8" />
-  <title>Clarus Portal</title>
+  <title>Clarus Employee Portal</title>
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@800&display=swap" rel="stylesheet">
   <link
     rel="stylesheet"
     href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css"
   />
+  <link href="{{ url_for('static', filename='css/portal.css') }}" rel="stylesheet" />
   <script src="https://cdn.tailwindcss.com"></script>
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
   <script src="https://unpkg.com/htmx.org@1.9.12"></script>
@@ -76,166 +77,6 @@
   </script>
   <script type="module" src="https://cdn.jsdelivr.net/npm/ldrs/dist/auto/hatch.js"></script>
 
-  <style>
-    .glass-effect {
-      background: rgba(255, 255, 255, 0.1);
-      backdrop-filter: blur(20px);
-      border: 1px solid rgba(255, 255, 255, 0.2);
-    }
-
-    .dark .glass-effect {
-      background: rgba(0, 0, 0, 0.3);
-      border: 1px solid rgba(255, 255, 255, 0.1);
-    }
-
-    .thread-gradient {
-      background: linear-gradient(45deg, #303294, #E5DA3C, #EE1A22, #303294);
-      background-size: 400% 400%;
-      animation: gradientShift 2s ease-in-out infinite;
-    }
-
-    @keyframes gradientShift {
-      0% { background-position: 0% 50%; }
-      50% { background-position: 100% 50%; }
-      100% { background-position: 0% 50%; }
-    }
-
-    .perspective-card {
-      perspective: 1000px;
-    }
-
-    .card-3d {
-      transform-style: preserve-3d;
-      transition: transform 0.6s cubic-bezier(0.23, 1, 0.32, 1);
-    }
-
-    .card-3d:hover {
-      transform: rotateY(10deg) rotateX(5deg) translateZ(20px);
-    }
-
-    .module-glow {
-      box-shadow: 0 0 30px rgba(48, 50, 148, 0.3);
-      transition: box-shadow 0.3s ease;
-    }
-
-    .module-glow:hover {
-      box-shadow: 0 0 50px rgba(48, 50, 148, 0.5);
-    }
-
-    .shimmer-bg {
-      display: inline-block;
-      position: relative;
-      color: transparent; /* required for background-clip */
-      background: linear-gradient(
-        90deg,
-        #ffffff 0%,
-        #dddddd 40%,
-        #ffffff 60%,
-        #cccccc 100%
-      );
-      background-size: 200% 100%;
-      background-clip: text;
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      animation: shimmer 2s linear infinite;
-    }
-
-    .shimmer-hover {
-      position: relative;
-      color: black; /* fallback */
-      font-weight: bold;
-      transition: all 0.3s ease;
-    }
-
-    .shimmer-hover:after {
-      content: attr(data-text);
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      color: transparent;
-      background: linear-gradient(
-        45deg,
-        transparent,
-        white 40%,
-        transparent
-      );
-      background-size: 200% 100%;
-      background-clip: text;
-      -webkit-background-clip: text;
-      -webkit-text-fill-color: transparent;
-      animation: shimmer 2s linear infinite;
-      opacity: 0;
-      pointer-events: none;
-      transition: opacity 0.3s ease;
-    }
-
-    .shimmer-hover:hover::after {
-      opacity: 1;
-    }
-    .animate-shimmer {
-      animation: shimmer 2s linear infinite;
-    }
-
-    .card-3d {
-      position: relative;
-      overflow: hidden;
-    }
-
-    .card-3d::before {
-      content: '';
-      position: absolute;
-      top: 0;
-      left: -100%;
-      width: 200%;
-      height: 100%;
-      background: linear-gradient(
-        120deg,
-        rgba(255, 255, 255, 0) 0%,
-        rgba(255, 255, 255, 0.3) 50%,
-        rgba(255, 255, 255, 0) 100%,
-        transparent 60%
-      );
-      transform: skewX(-25deg);
-      opacity: 0;
-      transition: opacity 1s ease;
-      pointer-events: none;
-      z-index: 1;
-    }
-
-    .card-3d:hover::before {
-      animation: metallic-glint 1.5s ease-in-out infinite;
-      opacity: 1;
-    }
-
-    @keyframes metallic-glint {
-      0% {
-        left: -75%;
-      }
-      50% {
-        left: 100%;
-      }
-      100% {
-        left: 100%;
-      }
-    }
-
-    .blink {
-      animation: blink 1s step-start 0s infinite;
-    }
-
-    @keyframes blink {
-      50% {
-        opacity: 0;
-      }
-    }
-
-    body.modal-open {
-      padding-right: 0 !important;
-    }
-
-  </style>
 </head>
 
 <body class="bg-gray-900 text-gray-100 min-h-screen transition-all duration-500">
@@ -278,13 +119,18 @@
           </div>
         </div>
 
-        <!-- Quick Stats (Only for privileged roles) -->
-        {% if current_user.role in ['admin','support','hr'] %}
+        <!-- Quick Stats -->
         <div class="glass-effect rounded-xl p-4">
           <h3 class="text-lg font-bold text-white mb-2">Quick Stats</h3>
-          <p class="text-gray-300">Pending Tickets: 12</p>
+          <div class="space-y-2">
+            {% for stat in stats %}
+            <div class="flex items-center justify-between gap-3 text-sm">
+              <span class="text-gray-300">{{ stat.label }}</span>
+              <span class="px-3 py-1 bg-white/10 text-white rounded-full">{{ stat.value }}</span>
+            </div>
+            {% endfor %}
+          </div>
         </div>
-        {% endif %}
       </aside>
 
       <!-- Main content -->
@@ -299,6 +145,9 @@
                 <h1 class="text-5xl font-bold text-white mb-3">
                   {{ welcome_message }}
                 </h1>
+                <p class="text-lg text-gray-300 max-w-2xl">
+                  {{ portal_subtitle }}
+                </p>
               </div>
               <a href="{{ url_for('routes.logout') }}" class="group relative px-8 py-3 bg-brandRed text-white font-semibold rounded-full shadow-lg hover:shadow-xl transition-all duration-300 transform hover:scale-105">
                 <span class="relative z-10">Logout</span>
@@ -327,7 +176,7 @@
                class="glass-effect p-6 mb-10 border-l-4 border-brandYellow rounded-xl shadow animate-fadeIn hidden">
             <div class="flex items-center justify-between mb-4">
               <h3 class="text-2xl font-bold text-brandYellow flex items-center gap-2">
-                <i class="bi bi-pencil-square text-xl text-brandYellow"></i> Post a New Reminder
+                <i class="bi bi-pencil-square text-xl text-brandYellow"></i> Post an Internal Update
               </h3>
               <button id="closeReminderBtn"
                       class="text-gray-400 hover:text-white transition">
@@ -371,7 +220,7 @@
                 <button type="button" id="cancelReminderBtn"
                         class="btn btn-secondary">Cancel</button>
                 <button type="submit"
-                        class="btn btn-warning text-black fw-bold">Post Reminder</button>
+                        class="btn btn-warning text-black fw-bold">Post Update</button>
               </div>
             </form>
           </div>
@@ -380,7 +229,7 @@
           <!-- Module Section -->
           <div class="mb-8">
             <h2 class="text-3xl font-bold text-center mb-4 text-white">
-              Available Modules
+              Your Workspace
             </h2>
             <div class="w-32 h-1 bg-brandBlue mx-auto rounded-full"></div>
           </div>
@@ -388,116 +237,46 @@
           <!-- Cards Grid -->
           <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
 
-            {% if 'troubleshooting' in modules %}
+            {% for module in modules %}
             <div class="perspective-card">
               <div class="card-3d glass-effect rounded-2xl p-8 module-glow group cursor-pointer">
                 <div class="shimmer-bg absolute inset-0 rounded-2xl animate-shimmer opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
                 <div class="relative z-10">
                   <div class="flex items-center gap-4 mb-6">
                     <div class="w-12 h-12 bg-brandBlue rounded-xl flex items-center justify-center shadow-lg">
+                      {% if module.icon == 'support' %}
                       <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                         <path d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"/>
                         <path d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"/>
                       </svg>
-                    </div>
-                    <h3 class="text-xl font-bold text-white">IT Support</h3>
-                  </div>
-                  <p class="text-gray-300 mb-6 leading-relaxed">Manage and resolve IT support tickets with advanced troubleshooting tools.</p>
-                  <a href="{{ url_for('troubleshooting.troubleshooting_dashboard') }}" class="inline-block bg-brandBlue text-white px-6 py-3 rounded-xl font-medium hover:shadow-lg transition-all duration-300 transform hover:scale-105">
-                    Open Dashboard
-                  </a>
-                </div>
-              </div>
-            </div>
-            {% endif %}
-
-            {% if 'inventory' in modules %}
-            <div class="perspective-card">
-              <div class="card-3d glass-effect rounded-2xl p-8 module-glow group cursor-pointer">
-                <div class="shimmer-bg absolute inset-0 rounded-2xl animate-shimmer opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                <div class="relative z-10">
-                  <div class="flex items-center gap-4 mb-6">
-                    <div class="w-12 h-12 bg-brandBlue rounded-xl flex items-center justify-center shadow-lg">
+                      {% elif module.icon == 'assets' %}
                       <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                         <path d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"/>
                       </svg>
-                    </div>
-                    <h3 class="text-xl font-bold text-white">Asset Inventory</h3>
-                  </div>
-                  <p class="text-gray-300 mb-6 leading-relaxed">Track and manage organizational IT assets with comprehensive monitoring.</p>
-                  <a href="{{ url_for('routes.aims') }}" class="inline-block bg-brandBlue text-white px-6 py-3 rounded-xl font-medium hover:shadow-lg transition-all duration-300 transform hover:scale-105">
-                    Access Inventory
-                  </a>
-                </div>
-              </div>
-            </div>
-            {% endif %}
-
-            {% if 'eip' in modules %}
-            <div class="perspective-card">
-              <div class="card-3d glass-effect rounded-2xl p-8 module-glow group cursor-pointer">
-                <div class="shimmer-bg absolute inset-0 rounded-2xl animate-shimmer opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                <div class="relative z-10">
-                  <div class="flex items-center gap-4 mb-6">
-                    <div class="w-12 h-12 bg-brandBlue rounded-xl flex items-center justify-center shadow-lg">
+                      {% elif module.icon == 'requests' %}
                       <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                         <path d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"/>
                       </svg>
-                    </div>
-                    <h3 class="text-xl font-bold text-white">Employee Portal</h3>
-                  </div>
-                  <p class="text-gray-300 mb-6 leading-relaxed">View and manage employee identity data with secure access controls.</p>
-                  <a href="{{ url_for('eip.eip_dashboard') }}" class="inline-block bg-brandBlue text-white px-6 py-3 rounded-xl font-medium hover:shadow-lg transition-all duration-300 transform hover:scale-105">
-                    Open EIP
-                  </a>
-                </div>
-              </div>
-            </div>
-            {% endif %}
-
-            {% if 'profile' in modules %}
-            <div class="perspective-card">
-              <div class="card-3d glass-effect rounded-2xl p-8 module-glow group cursor-pointer">
-                <div class="shimmer-bg absolute inset-0 rounded-2xl animate-shimmer opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                <div class="relative z-10">
-                  <div class="flex items-center gap-4 mb-6">
-                    <div class="w-12 h-12 bg-brandBlue rounded-xl flex items-center justify-center shadow-lg">
+                      {% elif module.icon == 'profile' %}
                       <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                         <path d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"/>
                       </svg>
-                    </div>
-                    <h3 class="text-xl font-bold text-white">Profile Management</h3>
-                  </div>
-                  <p class="text-gray-300 mb-6 leading-relaxed">Edit and view your personal profile information and preferences.</p>
-                  <a href="{{ url_for('profile.view_profile') }}" class="inline-block bg-brandBlue text-white px-6 py-3 rounded-xl font-medium hover:shadow-lg transition-all duration-300 transform hover:scale-105">
-                    Manage Profile
-                  </a>
-                </div>
-              </div>
-            </div>
-            {% endif %}
-
-            {% if 'manage_role' in modules %}
-            <div class="perspective-card">
-              <div class="card-3d glass-effect rounded-2xl p-8 module-glow group cursor-pointer">
-                <div class="shimmer-bg absolute inset-0 rounded-2xl animate-shimmer opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-                <div class="relative z-10">
-                  <div class="flex items-center gap-4 mb-6">
-                    <div class="w-12 h-12 bg-brandBlue rounded-xl flex items-center justify-center shadow-lg">
+                      {% else %}
                       <svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
                         <path d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"/>
                       </svg>
+                      {% endif %}
                     </div>
-                    <h3 class="text-xl font-bold text-white">Manage Roles</h3>
+                    <h3 class="text-xl font-bold text-white">{{ module.title }}</h3>
                   </div>
-                  <p class="text-gray-300 mb-6 leading-relaxed">Change access levels and permissions for users in the system.</p>
-                  <a href="{{ url_for('routes.manage_role') }}" class="inline-block bg-brandBlue text-white px-6 py-3 rounded-xl font-medium hover:shadow-lg transition-all duration-300 transform hover:scale-105">
-                    Open Role Manager
+                  <p class="text-gray-300 mb-6 leading-relaxed">{{ module.description }}</p>
+                  <a href="{{ url_for(module.endpoint) }}" class="inline-block bg-brandBlue text-white px-6 py-3 rounded-xl font-medium hover:shadow-lg transition-all duration-300 transform hover:scale-105">
+                    {{ module.cta }}
                   </a>
                 </div>
               </div>
             </div>
-            {% endif %}
+            {% endfor %}
 
           </div>
 
@@ -516,7 +295,7 @@
       <!-- Right Sidebar -->
       <aside class="flex justify-center h-full">
         <div class="flex flex-col gap-3 items-center justify-start w-full py-4  ">
-          <button onclick="document.documentElement.classList.toggle('dark')" class="glass-effect w-12 h-12 flex items-center justify-center rounded-full hover:scale-110 transition-all duration-300">
+          <button onclick="togglePortalTheme()" class="glass-effect w-12 h-12 flex items-center justify-center rounded-full hover:scale-110 transition-all duration-300">
               <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 dark:hidden text-brandYellow" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path d="M12 3v1m0 16v1m8.485-8.485h1M3.515 12.515h1M16.95 7.05l.707.707M6.343 17.657l.707.707M7.05 7.05L6.343 6.343M17.657 17.657l-.707.707M12 5a7 7 0 100 14 7 7 0 000-14z"/>
               </svg>
@@ -546,96 +325,6 @@
         </div>
       </aside>
   </div>
-  <script>
-    const phrases = [
-      'Weaving your digital threads.',
-      'Securing every byte.',
-      'Where IT meets clarity.'
-    ];
-
-    let phraseIndex = 0;
-    let charIndex = 0;
-    let isDeleting = false;
-    let tagline = null; // Will be set after DOM is fully loaded
-
-    function typewriter() {
-      const currentPhrase = phrases[phraseIndex];
-      tagline.textContent = currentPhrase.slice(0, charIndex);
-
-      if (!isDeleting) {
-        if (charIndex < currentPhrase.length) {
-          charIndex++;
-          setTimeout(typewriter, 40);
-        } else {
-          isDeleting = true;
-          setTimeout(typewriter, 500); // pause before deleting
-        }
-      } else {
-        if (charIndex > 0) {
-          charIndex--;
-          setTimeout(typewriter, 40);
-        } else {
-          isDeleting = false;
-          phraseIndex = (phraseIndex + 1) % phrases.length;
-          setTimeout(typewriter, 50); // pause before the next word
-        }
-      }
-    }
-
-    window.addEventListener('load', () => {
-      const loader = document.getElementById('loader');
-      const main = document.getElementById('main-content');
-      tagline = document.getElementById('typewriter'); // safe to get it now
-
-      if (tagline) {
-        tagline.style.display = 'inline';
-        console.log("Starting typewriter...");
-        typewriter(); // START IMMEDIATELY
-      } else {
-        console.warn("Tagline element not found!");
-      }
-
-        setTimeout(() => {
-          loader.style.opacity = '0';
-          loader.style.transform = 'scale(0.95)';
-
-          setTimeout(() => {
-            loader.style.display = 'none';
-            main.classList.remove('hidden');
-            main.style.animation = 'fadeIn 1s ease-in-out';
-          }, 400);
-        }, 2000); // loader duration was 7000
-      });
-  </script>
-  <script>
-    const toggleBtn = document.getElementById('toggleNotificationBtn');
-
-    toggleBtn.addEventListener('click', () => {
-      const notificationBox = document.getElementById('notificationBox');
-      if (notificationBox) {
-        notificationBox.classList.toggle('hidden');
-      }
-    });
-  </script>
-  <script>
-    const toggleReminderBtn = document.getElementById('toggleReminderBtn');
-    const newReminderBox = document.getElementById('newReminderBox');
-    const closeReminderBtn = document.getElementById('closeReminderBtn');
-    const cancelReminderBtn = document.getElementById('cancelReminderBtn');
-
-    function toggleReminder() {
-      newReminderBox.classList.toggle('hidden');
-    }
-
-    if (toggleReminderBtn) {
-      toggleReminderBtn.addEventListener('click', toggleReminder);
-    }
-    if (closeReminderBtn) {
-      closeReminderBtn.addEventListener('click', toggleReminder);
-    }
-    if (cancelReminderBtn) {
-      cancelReminderBtn.addEventListener('click', toggleReminder);
-    }
-  </script>
+  <script src="{{ url_for('static', filename='js/portal.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
I wanted to restructure the whole project because I feel like this is out of control, the project is becoming too iterative rather than going towards one direction. So, I decided to go towards making Clarus an internal HR system first, focusing on employee profile management, role-access, document uploads before proceeding for IT ticketing & asset tracking. Will update README for more info. 

Closes #125 

Changed the portal from a hardcoded module list into a structured HR-first dashboard model.
Removed the remaining internal EIP naming from the portal module config.
Reframed the main portal as an employee self-service dashboard.
Refactored the portal page so its custom visual effects and page logic live in dedicated static files.
Added shared frontend base files for repeated Bootstrap-theme behavior across the internal pages.
Reduced duplication in the page-specific asset files after introducing the shared base files.
Refactored the HR review queue page using the same feature-based asset structure.
Refactored the profile page so its frontend code is separated by feature instead of living inline inside the template.
Refined the order and wording of portal modules and stats.

What changed:
- Added `get_portal_modules(role)` to define portal cards in one place.
- Added `get_portal_stats(user_id, role)` to calculate real portal counts from the database.
- Updated `/portal` to pass `modules`, `stats`, and `portal_subtitle` into the template.
- Prioritized the profile module first.
- Prioritized the review queue for admin/HR/support roles.
- Changed stat labels to HR-style workflow language such as `Pending Approvals` and `Documents Awaiting Review`
- Changed the review module endpoint from `eip.change_requests_dashboard` to `change_requests.change_requests_dashboard`.
- Changed the module key from `eip` to `change_requests`.
- Updated labels to `Profile` and `HR Review Queue`.
- Changed the page title to `Clarus Employee Portal`.
- Replaced the fake ticket stat with real dynamic stats.
- Added an HR/self-service subtitle.
- Renamed reminder copy to internal-update language.
- Renamed `Available Modules` to `Your Workspace`.
- Switched module cards to data-driven rendering from the backend.
- Changed the animated tagline text to HR/self-service messaging.
- Moved portal-specific custom CSS into `app/static/css/portal.css`.
- Moved loader, typewriter, notification toggle, reminder toggle, and portal dark-mode button logic into `app/static/js/portal.js`.
- Updated `portal.html` to load those asset files.
- Replaced the inline dark-mode button action with `togglePortalTheme()`.
- Created `app/static/css/main.css` for:
  - shared light/dark theme variables
  - shared body theme styling
  - shared theme toggle button/icon styling
- Created `app/static/js/main.js` for:
  - shared `toggleTheme()` behavior
  - theme persistence through `localStorage`
  - a `clarus:theme-changed` event for page-specific listeners
- Updated `profile.html` and `change_requests.html` to load those shared files before their page-specific files.
- Removed shared Bootstrap theme and icon styling from `profile.css` and `change_requests.css`.
- Removed duplicated theme initialization/toggle logic from `profile.js`.
- Changed `change_requests.js` so it now listens for the shared `clarus:theme-changed` event and only performs row repaint behavior.
- Moved review-queue-specific inline CSS into `app/static/css/change_requests.css`.
- Moved review-queue-specific theme-toggle/repaint JavaScript into `app/static/js/change_requests.js`.
- Updated `change_requests.html` to load those asset files.
- Moved profile-specific inline CSS into `app/static/css/profile.css`.
- Moved profile-specific inline JavaScript into `app/static/js/profile.js`.
- Updated `profile.html` to load those asset files.
- Added a small `data-request-change-url` bridge on the page root so the extracted JavaScript can still submit change requests cleanly.

Why it matters:
- The portal now looks and reads like an HR/self-service product instead of an IT-first product.
- The portal is now much easier to evolve without keeping large script and style blocks inside the template.
- Repeated theme logic now lives in one place instead of being duplicated per page.
- The frontend structure is now more layered:
  - shared base files for common behavior
  - page files for feature-specific behavior
- The review queue now follows the same cleaner asset structure as the profile page.