### PR TITLE
Updated banking info section

### DIFF
--- a/app/templates/profile_sections/banking_info.html
+++ b/app/templates/profile_sections/banking_info.html
@@ -2,7 +2,7 @@
     <div class="alert alert-info d-flex align-items-start mb-3 small">
         <i class="bi bi-shield-lock me-2 mt-1 d-flex"></i>
         <div>
-          Sensitive banking details are locked. Use the <strong>Request Change</strong> button if you need to update them.
+          Banking details are treated as sensitive records. Use <strong>Request Change</strong> if any information needs to be updated.
         </div>
     </div>
     <div class="card-header">


### PR DESCRIPTION
Closes #141

Reworded the helper copy for banking information.

What changed:
- Framed banking information as a sensitive employee record.

Why it matters:
- This improves clarity and trust around why editing is controlled.