### PR TITLE
Ensured locked profile fields now use shared request metadata for banking info

### DIFF
--- a/app/templates/profile_sections/edit_banking_info.html
+++ b/app/templates/profile_sections/edit_banking_info.html
@@ -20,9 +20,9 @@
                 {% if not can_edit_directly %}
                     <button type="button"
                             class="btn btn-sm btn-outline-danger mt-1"
-                            data-bs-toggle="modal"
-                            data-bs-target="#changeModal"
-                            onclick="setChangeField('Bank Name', 'text')">
+                            data-change-field="Bank Name"
+                            data-change-type="text"
+                            onclick="openChangeRequestModal(this)">
                         Request Change
                     </button>
                 {% endif %}
@@ -37,9 +37,9 @@
                 {% if not can_edit_directly %}
                     <button type="button"
                             class="btn btn-sm btn-outline-danger mt-1"
-                            data-bs-toggle="modal"
-                            data-bs-target="#changeModal"
-                            onclick="setChangeField('Bank Account Number', 'text')">
+                            data-change-field="Bank Account Number"
+                            data-change-type="text"
+                            onclick="openChangeRequestModal(this)">
                         Request Change
                     </button>
                 {% endif %}
@@ -54,9 +54,9 @@
                 {% if not can_edit_directly %}
                     <button type="button"
                             class="btn btn-sm btn-outline-danger mt-1"
-                            data-bs-toggle="modal"
-                            data-bs-target="#changeModal"
-                            onclick="setChangeField('Account Holder Name', 'text')">
+                            data-change-field="Account Holder Name"
+                            data-change-type="text"
+                            onclick="openChangeRequestModal(this)">
                         Request Change
                     </button>
                 {% endif %}
@@ -76,71 +76,3 @@
         </div>
     </form>
 </div>
-
-<!-- Change Request Modal -->
-<div class="modal fade" id="changeModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <form class="modal-content" onsubmit="submitChangeRequest(event)">
-      <div class="modal-header">
-        <h5 class="modal-title">Request Change</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-      </div>
-      <div class="modal-body">
-        <input type="hidden" id="changeField" />
-        <div class="mb-3" id="inputGroup">
-          <!-- Input will be inserted here -->
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Reason (optional)</label>
-          <textarea class="form-control" id="changeNote" rows="2"></textarea>
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="submit" class="btn btn-primary">Submit Request</button>
-      </div>
-    </form>
-  </div>
-</div>
-
-<script>
-function setChangeField(field, type = "text") {
-  document.getElementById('changeField').value = field;
-  const group = document.getElementById('inputGroup');
-  group.innerHTML = '';
-
-  const label = document.createElement("label");
-  label.className = "form-label";
-  label.innerText = "New Value";
-  group.appendChild(label);
-
-  const input = document.createElement("input");
-  input.className = "form-control mt-1";
-  input.id = "newValue";
-  input.type = type;
-  input.required = true;
-
-  group.appendChild(input);
-}
-
-function submitChangeRequest(e) {
-  e.preventDefault();
-  const field = document.getElementById('changeField').value;
-  const new_value = document.getElementById('newValue').value;
-  const note = document.getElementById('changeNote').value;
-
-  fetch("{{ url_for('profile.request_change') }}?user_id={{ user_id }}", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ field, new_value, note })
-  }).then(res => {
-    if (res.ok) {
-      alert("Change request submitted.");
-      bootstrap.Modal.getInstance(document.getElementById('changeModal')).hide();
-    } else {
-      alert("Failed to submit change request.");
-    }
-  });
-}
-</script>
-
-<script src="https://unpkg.com/htmx.org@1.9.5"></script>


### PR DESCRIPTION
Closes #141 

Updated the edit screens so locked fields trigger the shared request-change UI consistently.

What changed:
- Replaced duplicate modal/script behavior with button metadata such as:
  - `data-change-field`
  - `data-change-type`
  - `data-change-options`
- Switched request buttons to call `openChangeRequestModal(this)`.

Why it matters:
- Banking locked fields now follow the same request-change behavior.