### PR TITLE
Improved wording, label, workflow & review states in document

### DIFF
--- a/app/templates/profile_sections/document_info.html
+++ b/app/templates/profile_sections/document_info.html
@@ -1,7 +1,15 @@
 <div id="document-upload-section">
     <div class="card shadow-sm my-4">
       <div class="card-body">
-        <h5 class="card-title">Document Uploads</h5>
+        <h5 class="card-title">Employee Documents</h5>
+        <p class="text-muted small">Upload supporting documents for your employee record. Accepted formats: PDF, JPG, and PNG.</p>
+        <p class="text-muted small mb-4">New uploads start as <strong>Pending</strong> until an HR reviewer updates the status.</p>
+
+        {% if document_status_message %}
+          <div class="alert alert-{{ 'success' if document_status_category == 'success' else 'danger' }} small">
+            {{ document_status_message }}
+          </div>
+        {% endif %}
 
         <form
           hx-post="{{ url_for('profile.upload_documents') }}?user_id={{ user_id }}"
@@ -24,7 +32,7 @@
             </select>
           </div>
           <div class="col-md-6">
-            <label class="form-label">Display Name</label>
+            <label class="form-label">Document Label</label>
             <input type="text" name="display_name" class="form-control bg-dark-subtle" required placeholder="e.g. Passport Page 1">
           </div>
           <div class="col-md-6">
@@ -32,7 +40,7 @@
             <input type="file" name="document" class="form-control bg-dark-subtle" accept=".pdf,.jpg,.jpeg,.png" required>
           </div>
           <div class="col-12">
-            <button class="btn btn-primary" type="submit">Upload</button>
+            <button class="btn btn-primary" type="submit">Upload Document</button>
           </div>
         </form>
 
@@ -44,8 +52,17 @@
               <div>
                 <strong>{{ loop.index }}. {{ doc.display_name or doc.document_type|capitalize }}</strong><br>
                 <small class="text-muted ms-2">
-                  Uploaded by: {{ doc.username }} on {{ doc.uploaded_at.strftime('%d %B %Y, %I:%M %p') }}
+                  Uploaded on {{ doc.uploaded_at.strftime('%d %B %Y, %I:%M %p') }}
                 </small>
+                <div class="mt-2">
+                  {% if doc.status == 'Approved' %}
+                    <span class="badge text-bg-success">Approved</span>
+                  {% elif doc.status == 'Declined' %}
+                    <span class="badge text-bg-danger">Declined</span>
+                  {% else %}
+                    <span class="badge text-bg-warning">Pending Review</span>
+                  {% endif %}
+                </div>
               </div>
                 <div>
                   <button
@@ -55,7 +72,7 @@
                     data-bs-target="#preview-{{ doc.id }}"
                     aria-expanded="false"
                     aria-controls="preview-{{ doc.id }}"
-                  >Toggle Preview</button>
+                  >Preview</button>
                   <button
                     class="btn btn-sm btn-danger"
                     hx-post="{{ url_for('profile.delete_document', doc_id=doc.id) }}?user_id={{ user_id }}"
@@ -65,6 +82,52 @@
                   >Delete</button>
                 </div>
               </div>
+
+              {% if current_user.role in ['admin', 'hr', 'support'] %}
+                <div class="d-flex flex-wrap gap-2 mt-3">
+                  {% if doc.status == 'Pending' %}
+                    <form
+                      hx-post="{{ url_for('profile.update_document_status_route', doc_id=doc.id) }}?user_id={{ user_id }}"
+                      hx-target="#document-upload-section"
+                      hx-swap="outerHTML"
+                      class="d-inline"
+                    >
+                      <input type="hidden" name="status" value="Approved">
+                      <button class="btn btn-sm btn-outline-success" type="submit">Approve</button>
+                    </form>
+                    <form
+                      hx-post="{{ url_for('profile.update_document_status_route', doc_id=doc.id) }}?user_id={{ user_id }}"
+                      hx-target="#document-upload-section"
+                      hx-swap="outerHTML"
+                      class="d-inline"
+                    >
+                      <input type="hidden" name="status" value="Declined">
+                      <button class="btn btn-sm btn-outline-danger" type="submit">Decline</button>
+                    </form>
+                  {% else %}
+                    <form
+                      hx-post="{{ url_for('profile.update_document_status_route', doc_id=doc.id) }}?user_id={{ user_id }}"
+                      hx-target="#document-upload-section"
+                      hx-swap="outerHTML"
+                      class="d-inline"
+                    >
+                      <input type="hidden" name="status" value="Pending">
+                      <button class="btn btn-sm btn-outline-warning" type="submit">Reopen Review</button>
+                    </form>
+                    <form
+                      hx-post="{{ url_for('profile.update_document_status_route', doc_id=doc.id) }}?user_id={{ user_id }}"
+                      hx-target="#document-upload-section"
+                      hx-swap="outerHTML"
+                      class="d-inline"
+                    >
+                      <input type="hidden" name="status" value="{% if doc.status == 'Approved' %}Declined{% else %}Approved{% endif %}">
+                      <button class="btn btn-sm btn-outline-secondary" type="submit">
+                        Mark {% if doc.status == 'Approved' %}Declined{% else %}Approved{% endif %}
+                      </button>
+                    </form>
+                  {% endif %}
+                </div>
+              {% endif %}
 
               <div class="collapse mt-3" id="preview-{{ doc.id }}">
                 {% set ext = doc.file_path.split('.')[-1] %}
@@ -84,10 +147,9 @@
           {% endfor %}
         </ul>
         {% else %}
-          <p class="text-muted">No documents uploaded yet.</p>
+          <p class="text-muted">No employee documents uploaded yet.</p>
         {% endif %}
       </div>
     </div>
 </div>
 
-<script src="https://unpkg.com/htmx.org@1.9.5"></script>


### PR DESCRIPTION
Closes #143 

**File:** `app/templates/profile_sections/document_info.html`

Improved the wording and labels in the employee documents area.
Improved the document workflow to support visible review states.
Turned document review into a visible workflow in the UI.
Changed the document UI so status is visible to everyone, but review actions are limited and workflow-aware.
Reworked the profile request-change experience so the whole page uses one shared request UI instead of duplicated section-level modal logic.
Removed extra HTMX script tags that were being reintroduced through swapped profile partials.

What changed:
- Renamed `Document Uploads` to `Employee Documents`.
- Added helper text for supporting documents.
- Renamed `Display Name` to `Document Label`.
- Changed `Upload` to `Upload Document`.
- Simplified the upload metadata line.
- Changed `Toggle Preview` to `Preview`.
- Updated the empty-state text.
- `document_info()` in `profile.py`now passes inline status-message variables into the template.
- `upload_documents()` now returns a success message saying the document is pending HR review.
- `delete_document()` now returns a delete success message.
- Added `/profile/document_status/<doc_id>` to let HR/admin/support mark a document as `Pending`, `Approved`, or `Declined`.
- Added a note explaining that uploads start as `Pending`.
- Added inline success/status messaging.
- Added status badges for each document.
- Added HR/admin/support actions to mark documents as `Pending`, `Approved`, or `Declined`.
- Kept the visible status badge for every document.
- Kept `Pending` visible to employees and managers.
- Limited approve/decline actions to managing roles only.
- Changed action behavior:
  - if status is `Pending`, managers see `Approve` and `Decline`
  - if status is not `Pending`, managers see `Reopen Review`
  - if status is not `Pending`, managers also see a separate `Mark Approved` or `Mark Declined` control to override the current decision
- Stopped showing the full pending-action button set after a decision is made.
- Added one page-level request-change overlay.
- Added shared JavaScript helpers to:
  - build the request input dynamically
  - open and close the request UI
  - reset request state between uses
  - submit change requests from one central flow
- Added request field support for:
  - text inputs
  - date inputs
  - select-style options such as gender and ID type
- Deleted repeated `<script src="https://unpkg.com/htmx.org@1.9.5"></script>` lines from those partials.

Why it matters:
- The document area reads more clearly as part of an employee records workflow.
- Documents are no longer just uploads; they are now part of a visible HR review workflow.
- The document experience now feels like part of the same approval-based V1 workflow as the change-request queue.
- The request-change workflow is now managed in one place instead of being repeated across multiple profile edit partials.
- HTMX now loads once from the main profile page instead of being injected repeatedly during profile interactions.