### PR TITLE
Streamlined employment section, ensured locked profile fields use shared request metadata & removed duplicated request-change modals from swapped partials

### DIFF
--- a/app/templates/profile_sections/edit_employment_info.html
+++ b/app/templates/profile_sections/edit_employment_info.html
@@ -36,9 +36,10 @@
           {% if not can_edit_directly %}
             <button type="button"
                     class="btn btn-sm btn-outline-danger mt-1"
-                    data-bs-toggle="modal"
-                    data-bs-target="#changeModal"
-                    onclick="setChangeField('{{ label }}', '{{ type }}')">
+                    data-change-field="{{ label }}"
+                    data-change-type="{{ type }}"
+                    {% if label == 'Employment Status' %}data-change-options="Full-time|Part-time|Intern|Terminated|Retired"{% endif %}
+                    onclick="openChangeRequestModal(this)">
               Request Change
             </button>
           {% endif %}
@@ -59,70 +60,3 @@
     </div>
   </form>
 </div>
-
-<!-- Change Request Modal -->
-<div class="modal fade" id="changeModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <form class="modal-content" onsubmit="submitChangeRequest(event)">
-      <div class="modal-header">
-        <h5 class="modal-title">Request Change</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-      </div>
-      <div class="modal-body">
-        <input type="hidden" id="changeField" />
-        <div class="mb-3" id="inputGroup"></div>
-        <div class="mb-3">
-          <label class="form-label">Reason (optional)</label>
-          <textarea class="form-control" id="changeNote" rows="2"></textarea>
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="submit" class="btn btn-primary">Submit Request</button>
-      </div>
-    </form>
-  </div>
-</div>
-
-<script>
-function setChangeField(field, type = "text") {
-  document.getElementById('changeField').value = field;
-  const group = document.getElementById('inputGroup');
-  group.innerHTML = '';
-
-  const label = document.createElement("label");
-  label.className = "form-label";
-  label.innerText = "New Value";
-  group.appendChild(label);
-
-  let input;
-
-  if (field === "Employment Status") {
-    input = document.createElement("select");
-    input.className = "form-select";
-    input.id = "newValue";
-
-    const defaultOption = document.createElement("option");
-    defaultOption.disabled = true;
-    defaultOption.selected = true;
-    defaultOption.text = "-- Select Status --";
-    input.appendChild(defaultOption);
-
-    ["Full-time", "Part-time", "Intern", "Terminated", "Retired"].forEach(status => {
-      const opt = document.createElement("option");
-      opt.value = status;
-      opt.text = status;
-      input.appendChild(opt);
-    });
-  } else {
-    input = document.createElement("input");
-    input.className = "form-control mt-1";
-    input.id = "newValue";
-    input.type = type;
-  }
-
-  input.required = true;
-  group.appendChild(input);
-}
-</script>
-
-<script src="https://unpkg.com/htmx.org@1.9.5"></script>

--- a/app/templates/profile_sections/employment_info.html
+++ b/app/templates/profile_sections/employment_info.html
@@ -2,7 +2,7 @@
     <div class="alert alert-info d-flex align-items-start mb-3 small">
         <i class="bi bi-shield-lock me-2 mt-1 d-flex"></i>
         <div>
-          Employment data may be synced with HR and some fields are locked. Click <strong>Request Change</strong> if updates are required.
+          Employment details are maintained through HR workflows. Use <strong>Request Change</strong> if something needs to be corrected.
         </div>
     </div>
     <div class="card-header">


### PR DESCRIPTION
Closes #144 

Reworded the helper copy for employment data.
Updated the edit screens so locked fields trigger the shared request-change UI consistently.
Removed the leftover per-partial request-change modal markup and inline modal scripts.

What changed:
- Explained employment data as part of HR-managed workflows.
- Replaced duplicate modal/script behavior with button metadata such as:
  - `data-change-field`
  - `data-change-type`
  - `data-change-options`
- Switched request buttons to call `openChangeRequestModal(this)`.
- Deleted duplicate `#changeModal` blocks from the edit partials.
- Deleted repeated inline modal helper functions that used to live inside those partials.

Why it matters:
- The employee understands that some fields are managed through review rather than direct editing.
- Employmentt locked fields now follow the same request-change behavior.
- The profile page no longer risks conflicting modal definitions after HTMX swaps.