### PR TITLE
Streamlined PII info, ensured locked profile fields now use shared request metadata & removed duplicate request-change modals from swapped partials

### DIFF
--- a/app/templates/profile_sections/edit_pii_info.html
+++ b/app/templates/profile_sections/edit_pii_info.html
@@ -12,9 +12,10 @@
         <input type="text" class="form-control bg-dark-subtle" name="id_type" value="{{ pii.id_type or '' }}" readonly>
         <button type="button"
                 class="btn btn-sm btn-outline-danger mt-1"
-                data-bs-toggle="modal"
-                data-bs-target="#changeModal"
-                onclick="setChangeField('ID Type', 'text')">
+                data-change-field="ID Type"
+                data-change-type="select"
+                data-change-options="Passport|IC"
+                onclick="openChangeRequestModal(this)">
           Request Change
         </button>
       </div>
@@ -23,9 +24,9 @@
         <input type="text" class="form-control bg-dark-subtle" name="id_number" value="{{ pii.id_number or '' }}" readonly>
         <button type="button"
                 class="btn btn-sm btn-outline-danger mt-1"
-                data-bs-toggle="modal"
-                data-bs-target="#changeModal"
-                onclick="setChangeField('ID Number', 'text')">
+                data-change-field="ID Number"
+                data-change-type="text"
+                onclick="openChangeRequestModal(this)">
           Request Change
         </button>
       </div>
@@ -34,9 +35,9 @@
         <input type="text" class="form-control bg-dark-subtle" name="citizenship" value="{{ pii.citizenship or '' }}" readonly>
         <button type="button"
                 class="btn btn-sm btn-outline-danger mt-1"
-                data-bs-toggle="modal"
-                data-bs-target="#changeModal"
-                onclick="setChangeField('Citizenship', 'text')">
+                data-change-field="Citizenship"
+                data-change-type="text"
+                onclick="openChangeRequestModal(this)">
           Request Change
         </button>
       </div>
@@ -65,70 +66,3 @@
     </div>
   </form>
 </div>
-
-<!-- Change Request Modal -->
-<div class="modal fade" id="changeModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <form class="modal-content" onsubmit="submitChangeRequest(event)">
-      <div class="modal-header">
-        <h5 class="modal-title">Request Change</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-      </div>
-      <div class="modal-body">
-        <input type="hidden" id="changeField" />
-        <div class="mb-3" id="inputGroup"></div>
-        <div class="mb-3">
-          <label class="form-label">Reason (optional)</label>
-          <textarea class="form-control" id="changeNote" rows="2"></textarea>
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="submit" class="btn btn-primary">Submit Request</button>
-      </div>
-    </form>
-  </div>
-</div>
-
-<script>
-function setChangeField(field, type = "text") {
-  document.getElementById('changeField').value = field;
-  const group = document.getElementById('inputGroup');
-  group.innerHTML = '';
-
-  const label = document.createElement("label");
-  label.className = "form-label";
-  label.innerText = "New Value";
-  group.appendChild(label);
-
-  let input;
-
-  if (field === "ID Type") {
-    input = document.createElement("select");
-    input.className = "form-select";
-    input.id = "newValue";
-
-    const defaultOption = document.createElement("option");
-    defaultOption.disabled = true;
-    defaultOption.selected = true;
-    defaultOption.text = "-- Select ID Type --";
-    input.appendChild(defaultOption);
-
-    ["Passport", "IC"].forEach(option => {
-      const opt = document.createElement("option");
-      opt.value = option;
-      opt.text = option;
-      input.appendChild(opt);
-    });
-  } else {
-    input = document.createElement("input");
-    input.className = "form-control mt-1";
-    input.id = "newValue";
-    input.type = type;
-  }
-
-  input.required = true;
-  group.appendChild(input);
-}
-</script>
-
-<script src="https://unpkg.com/htmx.org@1.9.5"></script>

--- a/app/templates/profile_sections/pii_info.html
+++ b/app/templates/profile_sections/pii_info.html
@@ -2,12 +2,12 @@
     <div class="alert alert-info d-flex align-items-start mb-3 small">
         <i class="bi bi-shield-lock me-2 mt-1 d-flex"></i>
         <div>
-          Identification details are protected. Use the <strong>Request Change</strong> button to request updates.
+          Identity details are protected and reviewed carefully. Use <strong>Request Change</strong> to submit an update for review.
         </div>
     </div>
     <div class="card-header">
         <h5 class="card-title d-flex justify-content-between">
-            Personal Identification Information
+            Identity Details
             <button class="btn btn-sm btn-primary float-end"
                     hx-get="{{ url_for('profile.edit_pii_info') }}?user_id={{ user_id }}"
                     hx-target="#pii-info-container"


### PR DESCRIPTION
Closes #146 

Updated the wording in the PII section.
Updated the edit screens so locked fields trigger the shared request-change UI consistently.
Removed the leftover per-partial request-change modal markup and inline modal scripts.

What changed:
- Rewrote the helper copy.
- Renamed `Personal Identification Information` to `Identity Details`.
- Replaced duplicate modal/script behavior with button metadata such as:
  - `data-change-field`
  - `data-change-type`
  - `data-change-options`
- Switched request buttons to call `openChangeRequestModal(this)`.
- Deleted duplicate `#changeModal` blocks from the edit partials.
- Deleted repeated inline modal helper functions that used to live inside those partials.

Why it matters:
- The wording is cleaner and more understandable for end users.
- PII info locked fields now follow the same request-change behavior.
- The profile page no longer risks conflicting modal definitions after HTMX swaps.