### PR TITLE
Streamlined vehicle section, ensured locked profile fields use shared request metadata & removed duplicated request-change modals from swapped partials

### DIFF
--- a/app/templates/profile_sections/edit_vehicles_info.html
+++ b/app/templates/profile_sections/edit_vehicles_info.html
@@ -45,9 +45,9 @@
                 <input type="hidden" name="plate_number" value="{{ vehicle.plate_number if vehicle else '' }}">
                 <button type="button"
                         class="btn btn-sm btn-outline-danger mt-1"
-                        data-bs-toggle="modal"
-                        data-bs-target="#changeModal"
-                        onclick="setChangeField('Plate Number', 'text')">
+                        data-change-field="Plate Number"
+                        data-change-type="text"
+                        onclick="openChangeRequestModal(this)">
                     Request Change
                 </button>
             </div>
@@ -63,9 +63,9 @@
                 <input type="hidden" name="parking_permit_id" value="{{ vehicle.parking_permit_id if vehicle else '' }}">
                 <button type="button"
                         class="btn btn-sm btn-outline-danger mt-1"
-                        data-bs-toggle="modal"
-                        data-bs-target="#changeModal"
-                        onclick="setChangeField('Parking Permit ID', 'text')">
+                        data-change-field="Parking Permit ID"
+                        data-change-type="text"
+                        onclick="openChangeRequestModal(this)">
                     Request Change
                 </button>
             </div>
@@ -81,71 +81,3 @@
         </div>
     </form>
 </div>
-
-<!-- Change Request Modal -->
-<div class="modal fade" id="changeModal" tabindex="-1" aria-hidden="true">
-  <div class="modal-dialog">
-    <form class="modal-content" onsubmit="submitChangeRequest(event)">
-      <div class="modal-header">
-        <h5 class="modal-title">Request Change</h5>
-        <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
-      </div>
-      <div class="modal-body">
-        <input type="hidden" id="changeField" />
-        <div class="mb-3" id="inputGroup">
-          <!-- Input will be inserted here -->
-        </div>
-        <div class="mb-3">
-          <label class="form-label">Reason (optional)</label>
-          <textarea class="form-control" id="changeNote" rows="2"></textarea>
-        </div>
-      </div>
-      <div class="modal-footer">
-        <button type="submit" class="btn btn-primary">Submit Request</button>
-      </div>
-    </form>
-  </div>
-</div>
-
-<script>
-function setChangeField(field, type = "text") {
-  document.getElementById('changeField').value = field;
-  const group = document.getElementById('inputGroup');
-  group.innerHTML = '';
-
-  const label = document.createElement("label");
-  label.className = "form-label";
-  label.innerText = "New Value";
-  group.appendChild(label);
-
-  const input = document.createElement("input");
-  input.className = "form-control mt-1";
-  input.id = "newValue";
-  input.type = type;
-  input.required = true;
-
-  group.appendChild(input);
-}
-
-function submitChangeRequest(e) {
-  e.preventDefault();
-  const field = document.getElementById('changeField').value;
-  const new_value = document.getElementById('newValue').value;
-  const note = document.getElementById('changeNote').value;
-
-  fetch("{{ url_for('profile.request_change') }}?user_id={{ user_id }}", {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ field, new_value, note })
-  }).then(res => {
-    if (res.ok) {
-      alert("Change request submitted.");
-      bootstrap.Modal.getInstance(document.getElementById('changeModal')).hide();
-    } else {
-      alert("Failed to submit change request.");
-    }
-  });
-}
-</script>
-
-<script src="https://unpkg.com/htmx.org@1.9.5"></script>

--- a/app/templates/profile_sections/vehicles_info.html
+++ b/app/templates/profile_sections/vehicles_info.html
@@ -2,11 +2,11 @@
     <div class="alert alert-info d-flex align-items-start mb-3 small mx-3 mt-3">
         <i class="bi bi-shield-lock me-2 mt-1 d-flex"></i>
         <div>
-          Security-sensitive fields like plate numbers and parking permits are locked. Click <strong>Request Change</strong> to notify admin.
+          Vehicle and parking details may support employee records and access workflows. Use <strong>Request Change</strong> for locked fields.
         </div>
     </div>
     <div class="card-header d-flex justify-content-between align-items-center">
-        <h5 class="card-title mb-0">Vehicles Information</h5>
+        <h5 class="card-title mb-0">Vehicle Information</h5>
         <button class="btn btn-sm btn-success"
                 hx-get="{{ url_for('profile.add_vehicles_info') }}?user_id={{ user_id }}"
                 hx-target="#vehicles-info-container"
@@ -33,7 +33,7 @@
             {% endfor %}
         </ul>
     {% else %}
-        <div class="card-body text-muted">No vehicles added.</div>
+        <div class="card-body text-muted">No vehicle records added yet.</div>
     {% endif %}
 </div>
 


### PR DESCRIPTION
Closes #147 

Reframed vehicle records within employee/access workflows.
Updated the edit screens so locked fields trigger the shared request-change UI consistently.
Removed the leftover per-partial request-change modal markup and inline modal scripts.

What changed:
- Renamed `Vehicles Information` to `Vehicle Information`.
- Updated helper copy.
- Updated empty-state text.
- Replaced duplicate modal/script behavior with button metadata such as:
  - `data-change-field`
  - `data-change-type`
  - `data-change-options`
- Switched request buttons to call `openChangeRequestModal(this)`.
- Deleted duplicate `#changeModal` blocks from the edit partials.
- Deleted repeated inline modal helper functions that used to live inside those partials.

Why it matters:
- The section now fits the HR/self-service model better.
- Vehicle locked fields now follow the same request-change behavior.
- The profile page no longer risks conflicting modal definitions after HTMX swaps.